### PR TITLE
Fixed rndphrase on sites with a non-standard portnumber

### DIFF
--- a/chrome/overlay.js
+++ b/chrome/overlay.js
@@ -10,7 +10,7 @@ chrome.extension.sendRequest({name: "getPreferences"},
         if(seed != null && seed.length > 0) {
             rndphrase.RndPhrase.seed_hash = seed;
         }
-        rndphrase.RndPhrase.patch_document(document.location.host, document);
+        rndphrase.RndPhrase.patch_document(document.location.hostname, document);
     });
 
 

--- a/conkeror/page-modes/rndphrase.js
+++ b/conkeror/page-modes/rndphrase.js
@@ -5,7 +5,7 @@ var rndPhraseExt = {
     onPageLoad: function(buffer) {
         if(!rndphrase.RndPhrase.self_test()) throw "Self test failed!";
         var doc = buffer.document;
-        rndphrase.RndPhrase.patch_document(doc.location.host, doc);
+        rndphrase.RndPhrase.patch_document(doc.location.hostname, doc);
     }
 };
 define_page_mode("rndphrase_mode",

--- a/firefox/content/rndphrase.xul
+++ b/firefox/content/rndphrase.xul
@@ -87,7 +87,7 @@ var rndPhraseExt = {
 
         var doc = aEvent.originalTarget;
         rndphrase.RndPhrase.seed_hash = hash;
-        rndphrase.RndPhrase.patch_document(doc.location.host, doc);
+        rndphrase.RndPhrase.patch_document(doc.location.hostname, doc);
     },
 };
 

--- a/js/js/rndphrase.js
+++ b/js/js/rndphrase.js
@@ -6,7 +6,7 @@ rndphrase.RndPhrase.seed = "";
 if (!rndphrase.RndPhrase.self_test()) {
     throw "Self test failed!";
 } else {
-    rndphrase.RndPhrase.patch_document(document.location.host, document);
+    rndphrase.RndPhrase.patch_document(document.location.hostname, document);
 }
 
 


### PR DESCRIPTION
Fixed rndphrase on sites with a non-standard portnumber by using document.location.hostname instead of document.location.host
