### PR TITLE
Made Makefile compatible with BSD find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ${WORK}/%: % data/suffix-list.js ${WORK}
 	@ rm -rf ${BUILD}/$< && \
 	mkdir -p $@ && touch $@ && \
 	cp -r $< work/ && \
-	for fname in $(shell find $< -type f -regex ".*\.\(js\|xul\|rdf\|dtd\|html\|json\)"); do \
+	for fname in $(shell find $< -type f | grep -e ".*\.\(js\|xul\|rdf\|dtd\|html\|json\)"); do \
 		${CPP} "$$fname" -o "work/$$fname" 3>/dev/null 2>/dev/null; \
 	done
 


### PR DESCRIPTION
The arguments for find only works with GNU find. I have patched the Makefile such that it works with BSD find as well as GNU

Tested on a Mac 10.8.3 and on Arch linux with GNU find v 4.4.2
