### PR TITLE
Implement Opera app store code review feedback

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -4,9 +4,9 @@ chrome.extension.onRequest.addListener(
         switch (request.name)
         {
         case "getPreferences":
-            sendResponse(
-                { prefSeed : localStorage["RndPhraseExtPrefSeed"] }
-            );
+            chrome.storage.sync.get('seed', function (data) {
+              sendResponse({ prefSeed : data.seed });
+            });
             break;
         }
     }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -21,7 +21,7 @@
     "description": QQQ(DESC),
     "version": QQQ(VERSION),
     "options_page": "options.html",
-    "permissios": [
+    "permissions": [
       "storage"
     ],
     "icons": {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -21,6 +21,9 @@
     "description": QQQ(DESC),
     "version": QQQ(VERSION),
     "options_page": "options.html",
+    "permissios": [
+      "storage"
+    ],
     "icons": {
         "64": "icon.png",
         "128": "icon.png"

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -1,8 +1,11 @@
+<!doctype html>
+
 <html>
   <head>
     <title>RndPhrase Options</title>
+    <script type="text/javascript" src="options.js"></script>
   </head>
-  <script type="text/javascript" src="options.js"></script>
+
   <body>
     <form id="options_form">
       <div style="width: 512px">

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -4,21 +4,31 @@
   </head>
   <script type="text/javascript" src="options.js"></script>
   <body>
-    <div style="width: 512px">
-      RndPhrase uses a personal seed along with your password to
-      improve security. It's something <i>unique</i> to you.<br/><br/>
-      For Example:
-      <ul>
-        <li>An e-mail address.</li>
-        <li>Your social security number.</li>
-        <li>Your birthday.</li>
-      </ul>
-      <i>The seed is encrypted before being stored.</i>
-    </div><br/>
-    Choose your personal seed:<br/>
-    <input type="text" style="width: 512px" id="rndphrase_seed" />
-    <br/><br/>
-    <div id="status"></div>
-    <button id="save">Save</button>
+    <form id="options_form">
+      <div style="width: 512px">
+        RndPhrase uses a personal seed along with your password to
+        improve security. It's something <i>unique</i> to you.<br/><br/>
+        For Example:
+        <ul>
+          <li>An e-mail address.</li>
+          <li>Your social security number.</li>
+          <li>Your birthday.</li>
+        </ul>
+        <i>The seed is encrypted before being stored.</i>
+      </div>
+
+      <br/>
+
+      <label>
+        Choose your personal seed:<br/>
+        <input type="text" style="width: 512px" id="rndphrase_seed" />
+      </label>
+
+      <br/><br/>
+
+      <div id="status"></div>
+
+      <button type="submit">Save</button>
+    </form>
   </body>
 </html>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -6,8 +6,8 @@ var MASK = "********";
 // Set status
 function set_status(msg) {
     var status = document.getElementById("status");
-    status.innerHTML = msg;
-    setTimeout(function(){ status.innerHTML = ""; }, 2000);
+    status.textContent = msg;
+    setTimeout(function(){ status.textContent = ""; }, 2000);
 }
 
 // Saves options to storage.

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -19,7 +19,7 @@ function save_options() {
     }
     var hash = rndphrase.CubeHash.hash(inp.value);
 
-    return chrome.storage.sync.set({ seed: seed }, function () {
+    return chrome.storage.sync.set({ seed: hash }, function () {
       inp.value = MASK;
       // Update status to let user know options were saved.
       set_status("Seed updated.");
@@ -40,12 +40,12 @@ function restore_options(callback) {
       callback();
     }
 
-    // Legacy localstorage migration code
+    // Legacy localStorage migration code
     if (localStorage.getItem("RndPhraseExtPrefSeed") !== null) {
       seed = localStorage.getItem("RndPhraseExtPrefSeed");
 
-      // Remove all traces of RndPhrase from ocalStorage
-      localstorage.removeItem("RndPhraseExtPrefSeed");
+      // Remove all traces of RndPhrase from localStorage
+      localStorage.removeItem("RndPhraseExtPrefSeed");
 
       return chrome.storage.sync.set({ seed: seed }, cb);
     }

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -50,8 +50,8 @@ function init() {
     document.getElementById('rndphrase_seed').addEventListener(
         'focus', reset_seed, false);
 
-    document.getElementById('save').addEventListener(
-        'click', save_options, false);
+    document.getElementById('options_form').addEventListener(
+        'submit', save_options, false);
 }
 
 window.onload = init;


### PR DESCRIPTION
Refs #14 
- [x] options.html - please use label tag for input.
- [x] Apply dedicated chrome.storage api instead of localStorage- options.js:121
- [x] use textContent when working with plain text.
- [x] modal.html and modal.js - redundant files. Please remove. **(Can't find these files, old build artifacts?)**
- [ ] options.html:1 - commented lines will be visible in rendered page. **(What commented lines?)**

The last two unchecked boxes I can't check. I've added my comments as to why.

These changes have not been tested, so I recommend a proper test run before doing a new release with them merged in. Especially the seed preference migration is important to verify works correctly
